### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -115,7 +115,7 @@ let doSomethingAsync = () =>
 `npm i reason-macros-bin`
 
 ```
-  "ppx-flags": "reason-macros-bin/ppx.js"
+  "ppx-flags": ["reason-macros-bin/ppx.js"]
 ```
 
 ### esy + dune


### PR DESCRIPTION
I think bucklescript needs ppx-flags to be an array if not the macro is ignored.