### PR TITLE
Fix ionicon sample code inside readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ let%macro.toplevel ionicon = (name: capIdent, iconName: capIdent) => {
           ~color: string=?,
           ~onClick: 'event => unit=?
         ) =>
-        string =
+        React.element =
         "react-ionicons/lib/$eval{iconName}";
     }
   ];
@@ -41,7 +41,7 @@ module Link = {
       ~color: string=?,
       ~onClick: 'event => unit=?
     ) =>
-    string =
+    React.element =
     "react-ionicons/lib/IosLink"
 };
 module Download = {
@@ -54,7 +54,7 @@ module Download = {
       ~color: string=?,
       ~onClick: 'event => unit=?
     ) =>
-    string =
+    React.element =
     "react-ionicons/lib/MdDownload"
 };
 ```


### PR DESCRIPTION
with string it won't compile

```
 1 │ ReactDOMRe.renderToElementWithId(<Icon.Link />, "root");
  
  This has type:
    React.componentLike({. "className": option(string),
                          "color": option(string),
                          "fontSize": option(string),
                          "onClick": option('a => unit)},
                         string)
      (defined as
      {. "className": option(string), "color": option(string),
        "fontSize": option(string), "onClick": option('a => unit)} =>
      string)
  But somewhere wanted:
    React.component({. "className": option(string), "color": option(string),
                      "fontSize": option(string),
                      "onClick": option('a => unit)})
      (defined as
      {. "className": option(string), "color": option(string),
        "fontSize": option(string), "onClick": option('a => unit)} =>
      React.element)
  
  The incompatible parts:
    string
    vs
    React.element

```